### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ The following events are provided:
 * ```(leafletMouseUp)```
 * ```(leafletMouseMove)```
 * ```(leafletMouseOver)``` 
+* ```(leafletMouseOut)``` 
 
 #### Map Zoom and Move: LeafletEvent
 The following events are provided:


### PR DESCRIPTION
fixed missing wrapper for `onmouseout` event,
note: dunno if that is all that needs to be 